### PR TITLE
[Fix]管理者画面の修正(コメント削除時の再読込アクションの変更)

### DIFF
--- a/app/controllers/article_comments_controller.rb
+++ b/app/controllers/article_comments_controller.rb
@@ -20,17 +20,32 @@ class ArticleCommentsController < ApplicationController
   def destroy
     @article_comment = ArticleComment.find(params[:id])
     @article = Article.find(@article_comment.article_id)
-      respond_to do |format|
-        if @article_comment.destroy
-          @article_comments = @article.article_comments.reverse
-          format.html
-          format.js { flash.now[:success] = "投稿を削除しました。" }
-        else
-          flash.now[:alert] = "投稿の削除に失敗しました。"
-          format.html
-          format.js { render 'error'}
-        end
+    respond_to do |format|
+      if @article_comment.destroy
+        @article_comments = @article.article_comments.reverse
+        format.html
+        format.js { flash.now[:success] = "投稿を削除しました。" }
+      else
+        flash.now[:alert] = "投稿の削除に失敗しました。"
+        format.html
+        format.js { render 'error'}
       end
+    end
+  end
+
+  def destroy_from_admin_page
+    @article_comment = ArticleComment.find(params[:id])
+    respond_to do |format|
+      if @article_comment.destroy
+        @article_comments = ArticleComments.all.reverse
+        format.html
+        format.js { flash.now[:success] = "投稿を削除しました。" }
+      else
+        flash.now[:alert] = "投稿の削除に失敗しました。"
+        format.html
+        format.js { render 'error'}
+      end
+    end
   end
 
   private

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -21,6 +21,7 @@ class ArticlesController < ApplicationController
     @stories = @article.stories.order(:created_at).reverse_order.page(params[:page]).per(10)
     @article_comments = @article.article_comments.reverse
     @article_comment = ArticleComment.new
+    @admin_comment_page = false
   end
 
   def edit

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -15,6 +15,7 @@ class StoriesController < ApplicationController
     @topics = @story.story_topics                 # 見出し
     @story_comments = @story.story_comments.reverse
     @story_comment = StoryComment.new
+    @admin_comment_page = false                   # 管理者ページからの表示？
     logging_visited_stories(@story)               # 閲覧履歴の記録
   end
 

--- a/app/controllers/story_comments_controller.rb
+++ b/app/controllers/story_comments_controller.rb
@@ -20,17 +20,32 @@ class StoryCommentsController < ApplicationController
   def destroy
     @story_comment = StoryComment.find(params[:id])
     @story = Story.find(@story_comment.story_id)
-      respond_to do |format|
-        if @story_comment.destroy
-          @story_comments = @story.story_comments.reverse
-          format.html
-          format.js { flash.now[:success] = "投稿を削除しました。" }
-        else
-          flash.now[:alert] = "投稿の削除に失敗しました。"
-          format.html
-          format.js { render 'error'}
-        end
+    respond_to do |format|
+      if @story_comment.destroy
+        @story_comments = @story.story_comments.reverse
+        format.html
+        format.js { flash.now[:success] = "投稿を削除しました。" }
+      else
+        flash.now[:alert] = "投稿の削除に失敗しました。"
+        format.html
+        format.js { render 'error'}
       end
+    end
+  end
+
+  def destroy_from_admin_page
+    @story_comment = StoryComment.find(params[:id])
+    respond_to do |format|
+      if @story_comment.destroy
+        @story_comments = StoryComment.all.reverse
+        format.html
+        format.js { flash.now[:success] = "投稿を削除しました。" }
+      else
+        flash.now[:alert] = "投稿の削除に失敗しました。"
+        format.html
+        format.js { render 'error'}
+      end
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,6 +56,7 @@ class UsersController < ApplicationController
   def admin_comments
     @article_comments = ArticleComment.order(:created_at).reverse_order.page(params[:page]).per(50).search(params[:search])
     @story_comments = StoryComment.order(:created_at).reverse_order.page(params[:page]).per(50).search(params[:search])
+    @admin_comment_page = true
   end
 
   def update

--- a/app/views/article_comments/_comments.html.erb
+++ b/app/views/article_comments/_comments.html.erb
@@ -17,7 +17,11 @@
           </p>
           <p><%= simple_format(comment.comment) %></p>
           <p><%= daytime_localize(comment.updated_at) %>
-            <% if same_user_or_admin?(comment.user) %>
+            <% if @admin_comment_page %>
+              <span>
+                / <%= link_to "削除", admin_destroies_article_comment_path(comment), method: :delete, remote: true, data: { confirm: '削除してもよろしいですか？' } %>
+              </span>
+            <% elsif same_user_or_admin?(comment.user) %>
               <span>
                 / <%= link_to "削除", article_comment_path(comment), method: :delete, remote: true, data: { confirm: '削除してもよろしいですか？' } %>
               </span>

--- a/app/views/article_comments/destroy_from_admin_page.js.erb
+++ b/app/views/article_comments/destroy_from_admin_page.js.erb
@@ -1,0 +1,6 @@
+$('#article-comment-lists').html("<%= j(render partial: '/article_comments/comments', locals:{article_comments: @article_comments}) %>");
+$('#comment-flash').html("<%= j(render partial: '/layouts/flash', locals:{flash: flash}) %>");
+$(function(){
+  setTimeout(function(){
+  $('#flash').fadeOut()}, 3000)
+});

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -45,7 +45,7 @@
         <div class="content-box-body">
           <p id="sub-content-hide" class="btn btn-sub2">ディスカッションを終了する</p>
           <div id="article-comment-lists">
-            <%= render partial: '/article_comments/comments', locals:{article_comments: @article_comments} %>
+            <%= render partial: '/article_comments/comments', locals:{article_comments: @article_comments, admin_comment_page: @admin_comment_page} %>
           </div>
         </div>
         <div class="content-box-foot">

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -68,7 +68,7 @@
         <div class="content-box-body">
           <div id="sub-content-hide" class="btn btn-sub2">ストーリに戻る</div>
           <div id="story-comment-lists" >
-            <%= render partial: '/story_comments/comments', locals:{story_comments: @story_comments} %>
+            <%= render partial: '/story_comments/comments', locals:{story_comments: @story_comments, admin_comment_page: @admin_comment_page} %>
           </div>
         </div>
         <div class="content-box-foot">

--- a/app/views/story_comments/_comments.html.erb
+++ b/app/views/story_comments/_comments.html.erb
@@ -17,7 +17,11 @@
           </p>
           <p><%= simple_format(comment.comment) %></p>
           <p><%= daytime_localize(comment.updated_at) %>
-            <% if same_user_or_admin?(comment.user) %>
+            <% if @admin_comment_page %>
+              <span>
+                / <%= link_to "削除", admin_destroies_story_comment_path(comment), method: :delete, remote: true, data: { confirm: '削除してもよろしいですか？' } %>
+              </span>
+            <% elsif same_user_or_admin?(comment.user) %>
               <span>
                 / <%= link_to "削除", story_comment_path(comment), method: :delete, remote: true, data: { confirm: '削除してもよろしいですか？' } %>
               </span>

--- a/app/views/story_comments/destroy_from_admin_page.js.erb
+++ b/app/views/story_comments/destroy_from_admin_page.js.erb
@@ -1,8 +1,5 @@
-$('#loading').show()
 $('#story-comment-lists').html("<%= j(render partial: '/story_comments/comments', locals:{story_comments: @story_comments}) %>");
 $('#comment-flash').html("<%= j(render partial: '/layouts/flash', locals:{flash: flash}) %>");
-$('#comment-post-field').html("<%= j(render partial: 'layouts/post_comment', locals:{parent: @story, parent_comment: @story_comment}) %>");
-$('#loading').hide()
 $(function(){
   setTimeout(function(){
   $('#flash').fadeOut()}, 3000)

--- a/app/views/users/admin_comments.html.erb
+++ b/app/views/users/admin_comments.html.erb
@@ -6,14 +6,14 @@
         <div class="content-box-body col-md-6 col-xs-6">
           <h4>- ディスカッション一覧</h4>
           <div id="article-comment-lists" class="user-admin-comments">
-            <%= render partial: '/article_comments/comments', locals:{article_comments: @article_comments} %>
+            <%= render partial: '/article_comments/comments', locals:{article_comments: @article_comments, admin_comment_page: @admin_comment_page} %>
           </div>
         </div>
 
         <div class="content-box-body col-md-6 col-xs-6">
           <h4>- トーク一覧</h4>
           <div id="story-comment-lists" class="user-admin-comments">
-            <%= render partial: '/story_comments/comments', locals:{story_comments: @story_comments} %>
+            <%= render partial: '/story_comments/comments', locals:{story_comments: @story_comments, admin_comment_page: @admin_comment_page} %>
           </div>
         </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,4 +25,6 @@ Rails.application.routes.draw do
   get 'comments/' => 'users#admin_comments', as: 'admin_comments'
   patch 'users/d/:id' => 'users#unsubscribe', as: 'unsubscribe_user'
   patch 'articles/ow/:id' => 'article_histories#overwrite', as: 'overwrite_article'
+  delete 'article_comments/:id/admin' => 'article_comments#destroy_from_admin_page', as: 'admin_destroies_article_comment'
+  delete 'story_comments/:id/admin' => 'story_comments#destroy_from_admin_page', as: 'admin_destroies_story_comment'
 end


### PR DESCRIPTION
管理者画面の修正(コメント削除時の再読込アクションの変更)
- 管理者画面からコメントを削除した際のアクションを新たに作成し、従来の削除アクションから分離
- 上記に伴うビュー・ルーティングの変更